### PR TITLE
Adding multi-step tests

### DIFF
--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -63,6 +63,42 @@ const features = [
     type: 'formOff',
     formType: 'essential',
   },
+  {
+    tcid: '8',
+    name: '@marketo multi-step 3 template (redirect)',
+    path: ['/drafts/nala/blocks/marketo/marketo-3-step-redirect'],
+    tags: '@marketo @marketoMultiStep @marketoMultiStep3 @marketoMultiStepRedirect @smoke @regression',
+    type: 'redirect',
+    formType: 'multi-step',
+    totalSteps: 3,
+  },
+  {
+    tcid: '9',
+    name: '@marketo multi-step 3 template (message)',
+    path: ['/drafts/nala/blocks/marketo/marketo-3-step-message'],
+    tags: '@marketo @marketoMultiStep @marketoMultiStep3 @marketoMultiStepMessage @smoke @regression',
+    type: 'message',
+    formType: 'multi-step',
+    totalSteps: 3,
+  },
+  {
+    tcid: '10',
+    name: '@marketo multi-step 2 template (redirect)',
+    path: ['/drafts/nala/blocks/marketo/marketo-2-step-redirect'],
+    tags: '@marketo @marketoMultiStep @marketoMultiStep2 @marketoMultiStepRedirect @smoke @regression',
+    type: 'redirect',
+    formType: 'multi-step',
+    totalSteps: 2,
+  },
+  {
+    tcid: '11',
+    name: '@marketo multi-step 2 template (message)',
+    path: ['/drafts/nala/blocks/marketo/marketo-2-step-message'],
+    tags: '@marketo @marketoMultiStep @marketoMultiStep2 @marketoMultiStepMessage @smoke @regression',
+    type: 'message',
+    formType: 'multi-step',
+    totalSteps: 2,
+  },
 ];
 
 export default features;

--- a/nala/selectors/marketo.block.page.js
+++ b/nala/selectors/marketo.block.page.js
@@ -31,7 +31,11 @@ export default class MarketoBlock {
     // -------------------------------------------------------------------------
     // UI elements
     // -------------------------------------------------------------------------
+    this.formEl = this.marketo.locator('form');
     this.submitButton = this.marketo.locator('#mktoButton_new');
+    this.nextButton = this.marketo.locator('#mktoButton_next');
+    this.backButton = this.marketo.locator('.back-btn');
+    this.stepIndicator = this.marketo.locator('.step-details .step');
     this.message = this.marketo.locator('.ty-message');
     this.title = this.marketo.locator('.marketo-title');
     this.description = this.marketo.locator('.marketo-description');
@@ -57,21 +61,17 @@ export default class MarketoBlock {
     };
   }
 
-  /**
-   * Navigates to the given URL and waits for the Marketo form to be ready.
-   * Falls back to networkidle if the email field is not immediately visible.
-   */
   async navigateTo(testPage) {
-    await this.page.goto(testPage);
-    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.goto(testPage, { waitUntil: 'domcontentloaded' });
     await expect(this.page).toHaveURL(testPage);
     // Scroll the marketo block into view — on mobile the form is often below
     // the fold and won't render until it enters the viewport.
-    await this.marketo.scrollIntoViewIfNeeded().catch(() => {});
-    await this.email.waitFor({ state: 'visible', timeout: 15000 }).catch(async () => {
-      await this.page.waitForLoadState('networkidle');
-      await expect(this.email).toBeVisible({ timeout: 10000 });
-    });
+    await this.marketo.scrollIntoViewIfNeeded();
+    // Form is ready once the email input is visible AND accepting input.
+    // `toBeEnabled` guards against a brief window where MktoForms2 has
+    // painted but not yet wired event listeners.
+    await expect(this.email).toBeVisible({ timeout: 20000 });
+    await expect(this.email).toBeEnabled();
   }
 
   /**
@@ -84,6 +84,108 @@ export default class MarketoBlock {
       () => window.mcz_marketoForm_pref?.form?.template,
     );
     return template || 'unknown';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Multi-step helpers
+  // ---------------------------------------------------------------------------
+
+  async isMultiStep() {
+    return this.marketo.evaluate((el) => el.classList.contains('multi-step'));
+  }
+
+  async getTotalSteps() {
+    return this.marketo.evaluate((el) => {
+      const match = el.className.match(/\bmulti-(\d+)\b/);
+      return match ? parseInt(match[1], 10) : null;
+    });
+  }
+
+  async getCurrentStep() {
+    const raw = await this.formEl.getAttribute('data-step');
+    return parseInt(raw, 10) || 1;
+  }
+
+  /**
+   * Waits for the step transition AND the block's post-step auto-focus
+   * setTimeout. Without this, a subsequent `.fill()` can race the handler
+   * and produce concatenated values on WebKit/Firefox.
+   */
+  async waitForStepTransition(direction, fromStep) {
+    await this.page.waitForFunction(
+      ({ dir, prev }) => {
+        const form = document.querySelector('.marketo form');
+        if (!form) return false;
+        const now = parseInt(form.dataset.step, 10);
+        const advanced = dir === 'next' ? now > prev : now < prev;
+        if (!advanced) return false;
+        // The block's auto-focus uses this exact selector — mirror it to
+        // detect that the setTimeout has run and focus has landed.
+        const expected = form.querySelector(
+          `.mktoFormRowTop[data-validate="${now}"]:not(.mktoHidden) input`,
+        );
+        return !!expected && document.activeElement === expected;
+      },
+      { dir: direction, prev: fromStep },
+      { timeout: 5000 },
+    );
+  }
+
+  async clickNext() {
+    const current = await this.getCurrentStep();
+    await this.nextButton.click();
+    await this.waitForStepTransition('next', current);
+  }
+
+  async clickBack() {
+    const current = await this.getCurrentStep();
+    await this.backButton.click();
+    await this.waitForStepTransition('back', current);
+  }
+
+  async checkMultiStepValidation() {
+    // Multi-step signals validation via `show-warnings` on the form,
+    // not the single-step error banner.
+    await expect(this.formEl).toHaveClass(/show-warnings/);
+    await expect(this.errorMessage).toHaveText('This field is required..');
+  }
+
+  async fillPersonalDetails(data) {
+    const { firstName, lastName, phone } = data;
+    await this.firstName.fill(firstName);
+    await this.lastName.fill(lastName);
+    await this.phone.fill(phone);
+    await this.jobTitle.selectOption({ index: 1 });
+    await this.functionalArea.selectOption({ index: 1 });
+  }
+
+  async fillCompanyDetails(data) {
+    const { company, postalCode } = data;
+    await this.company.click();
+    await this.company.fill(company);
+    await this.postalCode.fill(postalCode);
+    await this.primaryProductInterest.selectOption({ index: 2 });
+    // State dropdown is conditional on country; skip if it doesn't appear within 2s.
+    try {
+      await this.state.waitFor({ state: 'visible', timeout: 2000 });
+      await this.state.selectOption({ index: 1 });
+    } catch { /* state not shown for this country */ }
+  }
+
+  async fillMultiStepStep(stepNum, data) {
+    if (stepNum === 1) {
+      await this.country.selectOption({ index: 1 });
+      await this.email.fill(data.email);
+      return;
+    }
+    const totalSteps = await this.getTotalSteps();
+    if (totalSteps === 3) {
+      if (stepNum === 2) await this.fillPersonalDetails(data);
+      if (stepNum === 3) await this.fillCompanyDetails(data);
+    } else {
+      await this.fillPersonalDetails(data);
+      await this.fillCompanyDetails(data);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -20,7 +20,7 @@ test.describe('Marketo block test suite', () => {
   // -------------------------------------------------------------------------
   // Redirect tests: verify URL changes to ?submissionid after submission
   // -------------------------------------------------------------------------
-  features.filter((f) => f.type === 'redirect').forEach((feature) => {
+  features.filter((f) => f.type === 'redirect' && f.formType !== 'multi-step').forEach((feature) => {
     feature.path.forEach((path) => {
       test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {
         const testPage = buildTestUrl(baseURL, path);
@@ -54,7 +54,7 @@ test.describe('Marketo block test suite', () => {
   // -------------------------------------------------------------------------
   // Message tests: verify thank-you message appears and form fields hide
   // -------------------------------------------------------------------------
-  features.filter((f) => f.type === 'message').forEach((feature) => {
+  features.filter((f) => f.type === 'message' && f.formType !== 'multi-step').forEach((feature) => {
     feature.path.forEach((path) => {
       test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {
         const testPage = buildTestUrl(baseURL, path);
@@ -118,6 +118,83 @@ test.describe('Marketo block test suite', () => {
         await test.step('step-4: Verify content state toggles after submission', async () => {
           await expect(marketoBlock.postSubmissionContent).toBeVisible();
           await expect(marketoBlock.preSubmissionContent).toBeHidden();
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multi-step tests: verify 2-step / 3-step flow, Back-navigation
+  // preserves entered values, and final submission behaves as redirect/message
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.formType === 'multi-step').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {
+        const testPage = buildTestUrl(baseURL, path);
+        const testData = { ...TEST_DATA, email: `test+w${testInfo.workerIndex}t${feature.tcid}@adobetest.com` };
+        const { totalSteps } = feature;
+        console.info(`[Test Page]: ${testPage}`);
+
+        await test.step('Navigate and verify multi-step structure', async () => {
+          await marketoBlock.navigateTo(testPage);
+          expect(await marketoBlock.isMultiStep()).toBe(true);
+          expect(await marketoBlock.getTotalSteps()).toBe(totalSteps);
+          expect(await marketoBlock.getCurrentStep()).toBe(1);
+          await expect(marketoBlock.stepIndicator).toHaveText(`Step 1 of ${totalSteps}`);
+          await expect(marketoBlock.nextButton).toBeVisible();
+          await expect(marketoBlock.submitButton).toHaveClass(/mktoHidden/);
+          await expect(marketoBlock.backButton).toHaveCount(0);
+        });
+
+        await test.step('Verify validation warnings on empty Next', async () => {
+          await marketoBlock.nextButton.click();
+          await marketoBlock.checkMultiStepValidation();
+          expect(await marketoBlock.getCurrentStep()).toBe(1);
+        });
+
+        await test.step('Fill step 1 and advance', async () => {
+          await marketoBlock.fillMultiStepStep(1, testData);
+          await marketoBlock.clickNext();
+          expect(await marketoBlock.getCurrentStep()).toBe(2);
+          await expect(marketoBlock.stepIndicator).toHaveText(`Step 2 of ${totalSteps}`);
+          await expect(marketoBlock.backButton).toBeVisible();
+        });
+
+        await test.step('Back-navigation preserves entered values', async () => {
+          await marketoBlock.clickBack();
+          expect(await marketoBlock.getCurrentStep()).toBe(1);
+          await expect(marketoBlock.email).toHaveValue(testData.email);
+          await marketoBlock.clickNext();
+          expect(await marketoBlock.getCurrentStep()).toBe(2);
+        });
+
+        await test.step('Fill remaining steps and reach final step', async () => {
+          await marketoBlock.fillMultiStepStep(2, testData);
+          if (totalSteps === 3) {
+            await marketoBlock.clickNext();
+            expect(await marketoBlock.getCurrentStep()).toBe(3);
+            await expect(marketoBlock.stepIndicator).toHaveText('Step 3 of 3');
+            await marketoBlock.fillMultiStepStep(3, testData);
+          }
+        });
+
+        await test.step('Verify final-step UI shows Submit, hides Next', async () => {
+          await expect(marketoBlock.nextButton).toHaveClass(/mktoHidden/);
+          await expect(marketoBlock.submitButton).toBeVisible();
+          await expect(marketoBlock.submitButton).not.toHaveClass(/mktoHidden/);
+        });
+
+        await test.step('Submit the form', async () => {
+          await marketoBlock.submitButton.click();
+        });
+
+        await test.step(`Verify ${feature.type} after submission`, async () => {
+          if (feature.type === 'redirect') {
+            await expect(page).toHaveURL(/\?submissionid/, { timeout: 30000 });
+          } else {
+            await expect(marketoBlock.message).toBeAttached({ timeout: 30000 });
+            await expect(page).toHaveURL(testPage);
+          }
         });
       });
     });


### PR DESCRIPTION
Adds NALA coverage for Marketo multi-step: 2-step and 3-step variants with redirect and
message success types.

Resolves: [MWPW-191487](https://jira.corp.adobe.com/browse/MWPW-191487)

URL for testing:

https://multi-step--da-marketo--adobecom.aem.page/ 