### PR TITLE
Adding gh actions workflow.

### DIFF
--- a/.github/workflows/nala.yml
+++ b/.github/workflows/nala.yml
@@ -1,0 +1,58 @@
+name: NALA DA-Marketo
+
+on:
+  pull_request:
+    branches: [main, stage]
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nala-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browsers + OS deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright OS deps only (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Run NALA tests
+        run: npm run test:nala
+
+      - name: Upload results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nala-results-${{ github.run_id }}
+          path: nala/results/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "7.17.7",
         "@babel/eslint-parser": "7.17.0",
         "@esm-bundle/chai": "4.3.4-fix.0",
-        "@playwright/test": "~1.51.0",
+        "@playwright/test": "~1.59.0",
         "@web/dev-server-import-maps": "^0.2.1",
         "@web/test-runner": "^0.18.2",
         "@web/test-runner-commands": "^0.9.0",
@@ -817,13 +817,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9301,13 +9301,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9320,9 +9320,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/adobecom/college#readme",
   "devDependencies": {
-    "@playwright/test": "~1.51.0",
+    "@playwright/test": "~1.59.0",
     "browserstack-node-sdk": "1.34.31",
     "@babel/core": "7.17.7",
     "@babel/eslint-parser": "7.17.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
 
   retries: 1,
 
-  workers: process.env.CI ? 6 : 2,
+  workers: 2,
 
   /* Reporter */
   reporter: process.env.CI


### PR DESCRIPTION
- Adding a Github Actions workflow that runs the Nala tests on a schedule, on PRs to main/stage, and manually. Runs against the full 6-project matrix (chromium, firefox, webkit + 3 mobile/tablet emulations).

- Caches browsers for faster execution. 

- Updating playwright version to the latest to run against latest browser versions.


Resolves: [MWPW-191709](https://jira.corp.adobe.com/browse/MWPW-191709)

URL for testing:

https://nala-gh-actions--da-marketo--adobecom.aem.page/