### PR TITLE
MWPW-194730 CDN Loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nala/results/*
 log/*
 .claude/
 .cursor/
+.worktrees/

--- a/build/sync-marketo/filename-mapping.js
+++ b/build/sync-marketo/filename-mapping.js
@@ -116,7 +116,9 @@ function findRawPath(content, formId) {
 
 function applyLayout(rawPath) {
   if (!rawPath) return null;
-  if (rawPath.includes('/')) return rawPath;
+  if (rawPath.includes('/')) {
+    return rawPath.startsWith('scripts/') ? rawPath : `scripts/${rawPath}`;
+  }
   const dir = folderForBasename(rawPath);
   return dir ? `${dir}/${rawPath}` : rawPath;
 }

--- a/mkto/mkto.js
+++ b/mkto/mkto.js
@@ -2,7 +2,7 @@
 import { LIBS } from './constants.js';
 
 const base = new URL('.', import.meta.url).href;
-const { loadScript } = await import(`${LIBS}/utils/utils.js`);
+const { loadScript, loadLink } = await import(`${LIBS}/utils/utils.js`);
 
 // Prod form 2277 scripts
 const SCRIPTS = [
@@ -28,6 +28,8 @@ export default async function loadMkto(marketoHost, munchkinID, formID) {
 
   const { MktoForms2 } = window;
   if (!MktoForms2) throw new Error('Marketo forms not loaded');
+
+  SCRIPTS.forEach((src) => loadLink(`${base}${src}`, { rel: 'preload', as: 'script' }));
 
   MktoForms2.loadForm(`https://${marketoHost}`, munchkinID, formID, () => {
     SCRIPTS.reduce(

--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -99,6 +99,14 @@ const features = [
     formType: 'multi-step',
     totalSteps: 2,
   },
+  {
+    tcid: '12',
+    name: '@marketo CDN routing — mkto/ path assertion',
+    path: ['/drafts/nala/blocks/marketo/essential'],
+    tags: '@marketo @marketoCdnRouting @regression',
+    type: 'cdnRouting',
+    formType: 'essential',
+  },
 ];
 
 export default features;

--- a/nala/selectors/marketo.block.page.js
+++ b/nala/selectors/marketo.block.page.js
@@ -159,7 +159,7 @@ export default class MarketoBlock {
       { dir: direction, prev: fromStep },
       { timeout: 5000 },
     );
-    await this.page.waitForTimeout(150);
+    await this.page.waitForTimeout(110);
   }
 
   async clickNext() {
@@ -198,7 +198,7 @@ export default class MarketoBlock {
     await this.primaryProductInterest.selectOption({ index: 2 });
     // State dropdown is conditional on country; skip if it doesn't appear within 2s.
     try {
-      await this.state.waitFor({ state: 'visible', timeout: 2000 });
+      await this.state.waitFor({ state: 'visible', timeout: 300 });
       await this.state.selectOption({ index: 1 });
     } catch { /* state not shown for this country */ }
   }
@@ -262,7 +262,7 @@ export default class MarketoBlock {
     // use index 2 to guarantee a real product value is selected
     await this.primaryProductInterest.selectOption({ index: 2 });
     // State only renders for certain countries — interact only if visible
-    await this.state.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+    await this.state.waitFor({ state: 'visible', timeout: 300 }).catch(() => {});
     if (await this.state.isVisible()) {
       await this.state.selectOption({ index: 1 });
     }

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -5,7 +5,8 @@ import TEST_DATA from '../utils/marketo.test.data.js';
 
 const UPDATE_PLACEHOLDERS = 'Please check placeholders.json';
 const miloLibs = process.env.MILO_LIBS || '';
-const marketoLibs = process.env.MARKETO_LIBS ? `${miloLibs ? '&' : '?'}marketolibs=${process.env.MARKETO_LIBS}` : '';
+const cdnBranch = process.env.MARKETO_LIBS || '';
+const marketoLibs = cdnBranch ? `${miloLibs ? '&' : '?'}marketolibs=${cdnBranch}` : '';
 const buildTestUrl = (baseURL, path) => `${baseURL}${path}${miloLibs}${marketoLibs}`.toLowerCase();
 
 test.describe('Marketo block test suite', () => {
@@ -197,6 +198,61 @@ test.describe('Marketo block test suite', () => {
             await expect(marketoBlock.message).toBeAttached({ timeout: 30000 });
             await expect(page).toHaveURL(testPage);
           }
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CDN routing tests: verify mkto/ path is used, old path never requested
+  // Uses MARKETO_LIBS (set to the PR branch by nala.yml) as the ?marketolibs= value.
+  // 'main'/'stage' are skipped — da-bacom maps them to http:// which browsers block as mixed content.
+  // Once Akamai CDN is wired (target: Jun 23 2026) these can run against business.adobe.com directly.
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.type === 'cdnRouting').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }) => {
+        // MARKETO_LIBS is set to the PR branch by nala.yml (github.head_ref); unset on scheduled runs.
+        // 'main' and 'stage' map to http:// in da-bacom getMarketoLibs — skip those to avoid mixed-content failures.
+        test.skip(
+          !cdnBranch || cdnBranch === 'main' || cdnBranch === 'stage',
+          'CDN routing test requires MARKETO_LIBS env var set to a non-main/stage branch',
+        );
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+
+        const responses = new Map();
+        page.on('response', (res) => {
+          const { pathname } = new URL(res.url());
+          if (pathname.includes('/mkto/') || pathname.includes('/blocks/da-marketo/')) {
+            responses.set(res.url(), res.status());
+          }
+        });
+
+        await test.step('step-1: navigate and wait for form', async () => {
+          await marketoBlock.navigateTo(testPage);
+        });
+
+        await test.step('step-2: mkto/libs.js returns 200', async () => {
+          const entry = [...responses.entries()].find(([url]) => url.includes('/mkto/libs.js'));
+          expect(entry, 'mkto/libs.js was not requested').toBeTruthy();
+          expect(entry[1], `mkto/libs.js returned ${entry?.[1]}`).toBe(200);
+        });
+
+        await test.step('step-3: mkto/blocks/da-marketo/da-marketo.js returns 200', async () => {
+          const entry = [...responses.entries()].find(([url]) => url.includes('/mkto/blocks/da-marketo/da-marketo.js'));
+          expect(entry, 'mkto/blocks/da-marketo/da-marketo.js was not requested').toBeTruthy();
+          expect(entry[1], `mkto/blocks/da-marketo/da-marketo.js returned ${entry?.[1]}`).toBe(200);
+        });
+
+        await test.step('step-4: no requests to old path (without /mkto/ prefix)', async () => {
+          const oldPathReqs = [...responses.keys()].filter(
+            (url) => /\/blocks\/da-marketo\//.test(url) && !/\/mkto\/blocks\/da-marketo\//.test(url),
+          );
+          expect(
+            oldPathReqs,
+            `old-path requests found: ${oldPathReqs.join(', ')}`,
+          ).toHaveLength(0);
         });
       });
     });


### PR DESCRIPTION
* Preload mkto scripts with \`loadLink\` before \`MktoForms2.loadForm\` fires, reducing sequential load time
* Add Nala CDN routing regression test asserting \`mkto/\` paths return 200 and old paths are never requested
* Fix \`applyLayout\` path normalization in sync-marketo build tool
* Reduce Nala state dropdown and step-nav wait timeouts

Resolves: [MWPW-194730](https://jira.corp.adobe.com/browse/MWPW-194730)

**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.page/martech=off
- After: https://mkto-loading--da-marketo--adobecom.aem.page/?martech=off

**BACOM URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/request-consultation?marketolibs=main&martech=off
- After: https://main--da-bacom--adobecom.aem.live/request-consultation?marketolibs=mkto-loading&martech=off