### PR TITLE
MWPW-196016 Upgrade Node.js to 24 in CI workflows

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
* Bump Node 20 (EOL Apr 2026) to Node 24 in \`run-lint.yml\` and \`run-tests.yaml\`

Resolves: [MWPW-196016](https://jira.corp.adobe.com/browse/MWPW-196016)

**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live
- After: https://node-24-ci--da-marketo--adobecom.aem.live