### PR TITLE
Add ?marketolibs= branch override to da-marketo scripts.js

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -27,6 +27,17 @@ export const [setLibs, getLibs] = (() => {
   ];
 })();
 
+export function getMarketoLibs(location = window.location) {
+  const { hostname, search } = location;
+  if (!['.aem.', '.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '../mkto/libs.js';
+  const branch = new URLSearchParams(search).get('marketolibs');
+  if (!branch) return '../mkto/libs.js';
+  if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid marketolibs branch name.');
+  if (branch === 'local') return 'http://localhost:6586/mkto/libs.js';
+  const origin = branch.includes('--') ? `https://${branch}.aem.live` : `https://${branch}--da-marketo--adobecom.aem.live`;
+  return `${origin}/mkto/libs.js`;
+}
+
 function decorateArea() {
   const eagerLoad = (parent, selector) => {
     const img = parent.querySelector(selector);
@@ -91,7 +102,7 @@ const miloLibs = setLibs('/libs');
 (async function loadPage() {
   const { loadArea, getConfig, setConfig } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });
-  const mkto = await import('../mkto/libs.js');
+  const mkto = await import(getMarketoLibs());
   mkto.register({ getConfig, setConfig });
   await loadArea();
 }());

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { setLibs } from '../../scripts/scripts.js';
+import { setLibs, getMarketoLibs } from '../../scripts/scripts.js';
 
 describe('Libs', () => {
   it('Default Libs', () => {
@@ -41,5 +41,36 @@ describe('Libs', () => {
     };
     const libs = setLibs('/libs', location);
     expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
+  });
+});
+
+describe('Marketo Libs', () => {
+  const tests = [
+    // Prod hosts always use the co-located pipeline, even with a param.
+    ['https://business.adobe.com', '../mkto/libs.js'],
+    ['https://business.adobe.com?marketolibs=foo', '../mkto/libs.js'],
+    // aem/page hosts with no param: co-located.
+    ['https://main--da-marketo--adobecom.aem.live/', '../mkto/libs.js'],
+    ['https://main--da-marketo--adobecom.aem.page/', '../mkto/libs.js'],
+    // aem/page hosts with a branch param: load the block + scripts from that branch origin.
+    ['https://main--da-marketo--adobecom.aem.live/?marketolibs=fix-privacy-links', 'https://fix-privacy-links--da-marketo--adobecom.aem.live/mkto/libs.js'],
+    ['https://main--da-marketo--adobecom.aem.page/?marketolibs=foo', 'https://foo--da-marketo--adobecom.aem.live/mkto/libs.js'],
+    ['https://main--da-marketo--adobecom.aem.live/?marketolibs=local', 'http://localhost:6586/mkto/libs.js'],
+    ['https://main--da-marketo--adobecom.aem.live/?marketolibs=awesome--da-marketo--forkedowner', 'https://awesome--da-marketo--forkedowner.aem.live/mkto/libs.js'],
+    // localhost dev server.
+    ['http://localhost:6586/', '../mkto/libs.js'],
+    ['http://localhost:6586/?marketolibs=foo', 'https://foo--da-marketo--adobecom.aem.live/mkto/libs.js'],
+    ['http://localhost:6586/?marketolibs=local', 'http://localhost:6586/mkto/libs.js'],
+  ];
+
+  tests.forEach(([url, expected]) => {
+    it(`Resolves marketo libs for ${url}`, () => {
+      expect(getMarketoLibs(new URL(url))).to.equal(expected);
+    });
+  });
+
+  it('Throws on an invalid marketolibs branch name', () => {
+    expect(() => getMarketoLibs(new URL('https://main--da-marketo--adobecom.aem.live/?marketolibs=foo.bar')))
+      .to.throw('Invalid marketolibs branch name');
   });
 });


### PR DESCRIPTION
* Add a `?marketolibs=<branch>` override to da-marketo `scripts/scripts.js`, mirroring the `marketolibs` pattern in da-bacom, so da-marketo can load its own block + `mkto/` scripts from another da-marketo branch origin.
* This lets an allowlisted page (e.g. `main--da-marketo`) run a branch's form code — required to E2E-test region/consent behavior that only resolves on allowlisted origins. Unblocks the #19 locale fix and its nala E2E.

Resolves: [MWPW-198384](https://jira.corp.adobe.com/browse/MWPW-198384)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live/drafts/nala/blocks/marketo/full?martech=off
- After: https://marketolibs-branch--da-marketo--adobecom.aem.live/drafts/nala/blocks/marketo/full?marketolibs=fix-privacy-links&martech=off