### PR TITLE
MWPW-189425 Resolve privacy/legal links to URL path locale

### DIFF
--- a/mkto/scripts/30_privacy/privacy_validation_process.js
+++ b/mkto/scripts/30_privacy/privacy_validation_process.js
@@ -1,9 +1,9 @@
 // ##
-// ## Updated 20250929T200801
+// ## Updated 20260612T141917
 // ##
 // ##
 // ##
-// ## 30_privacy/privacy_validation_process.js - 20250929T200801
+// ## 30_privacy/privacy_validation_process.js - 20260612T141917
 // ##
 // ##
 
@@ -532,6 +532,13 @@ if (typeof window?.privacyValidation != "function") {
       return null;
     }
 
+    function check_url_path_locale() {
+      const pathSegment = window.location.pathname.split("/").filter(Boolean)[0];
+      if (!pathSegment) return null;
+      const knownRegionalSites = new Set(Object.values(adobeRegionalSite));
+      return knownRegionalSites.has(pathSegment) ? pathSegment : null;
+    }
+
     function check_browser_lang() {
       const sources = [
         window?.adobeid?.locale,
@@ -967,35 +974,38 @@ if (typeof window?.privacyValidation != "function") {
           tempPrivacyLinks[key] = matchingRulePrivacyLinks[key];
         }
 
-        let rSLChk = check_content_lang();
-        if (rSLChk == null || rSLChk == "") {
-          rSLChk = "en_us";
-        }
-        if (rSLChk.length < 3 || rSLChk.indexOf("_") < 0) {
-          rSLChk = rSLChk + "_" + rSLChk;
-        }
-        let localRegionalSite = adobeRegionalSite[rSLChk];
-        if (typeof localRegionalSite == "undefined" || localRegionalSite == null) {
-          localRegionalSite = "";
-        }
-        if (localRegionalSite == "") {
-          if (localRegionalSite.indexOf("en") != 0) {
-            let rSLChk = check_content_lang();
-            if (rSLChk == null || rSLChk == "") {
-              rSLChk = "en_us";
+        let localRegionalSite = check_url_path_locale();
+        if (localRegionalSite === null) {
+          let rSLChk = check_content_lang();
+          if (rSLChk == null || rSLChk == "") {
+            rSLChk = "en_us";
+          }
+          if (rSLChk.length < 3 || rSLChk.indexOf("_") < 0) {
+            rSLChk = rSLChk + "_" + rSLChk;
+          }
+          localRegionalSite = adobeRegionalSite[rSLChk];
+          if (typeof localRegionalSite == "undefined" || localRegionalSite == null) {
+            localRegionalSite = "";
+          }
+          if (localRegionalSite == "") {
+            if (localRegionalSite.indexOf("en") != 0) {
+              let rSLChkFallback = check_content_lang();
+              if (rSLChkFallback == null || rSLChkFallback == "") {
+                rSLChkFallback = "en_us";
+              }
+              rSLChkFallback = rSLChkFallback.substring(0, 2);
+              rSLChkFallback = rSLChkFallback.toLowerCase();
+              let keys = Object.keys(adobeRegionalSite);
+              let filteredKeys = keys.filter((key) => key.startsWith(rSLChkFallback));
+              if (filteredKeys.length > 0) {
+                logPrivacy(
+                  "Regional Site not found for [" + rSLChkFallback + "] using [" + filteredKeys[0] + "]"
+                );
+                localRegionalSite = adobeRegionalSite[filteredKeys[0]];
+              }
+            } else {
+              logPrivacy("Regional Site not found for [" + rSLChk + "]");
             }
-            rSLChk = rSLChk.substring(0, 2);
-            rSLChk = rSLChk.toLowerCase();
-            let keys = Object.keys(adobeRegionalSite);
-            let filteredKeys = keys.filter((key) => key.startsWith(rSLChk));
-            if (filteredKeys.length > 0) {
-              logPrivacy(
-                "Regional Site not found for [" + rSLChk + "] using [" + filteredKeys[0] + "]"
-              );
-              localRegionalSite = adobeRegionalSite[filteredKeys[0]];
-            }
-          } else {
-            logPrivacy("Regional Site not found for [" + rSLChk + "]");
           }
         }
         let base_site = "" + mcz_marketoForm_pref?.form?.baseSite;
@@ -1116,3 +1126,5 @@ if (typeof window?.privacyValidation != "function") {
 
 // ##
 // ##
+
+//# sourceURL=privacy_validation_process.js

--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -161,6 +161,15 @@ const features = [
     expectedProgramId: '99999',
     expectedSetBy: 'authored',
   },
+  {
+    tcid: '19',
+    name: '@marketo /ie/ locale privacy link',
+    path: ['/ie/acrobat/contact'],
+    tags: '@marketo @marketoPrivacyLocale @regression',
+    type: 'privacyLocale',
+    formType: 'essential',
+    locale: 'ie',
+  },
 ];
 
 export default features;

--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -164,11 +164,22 @@ const features = [
   {
     tcid: '19',
     name: '@marketo /ie/ locale privacy link',
-    path: ['/ie/acrobat/contact'],
+    path: ['/ie/drafts/nala/blocks/marketo/full'],
     tags: '@marketo @marketoPrivacyLocale @regression',
     type: 'privacyLocale',
-    formType: 'essential',
+    formType: 'full',
     locale: 'ie',
+    countryLabel: 'Ireland',
+  },
+  {
+    tcid: '20',
+    name: '@marketo /jp/ locale form translation',
+    path: ['/jp/drafts/nala/blocks/marketo/essential'],
+    tags: '@marketo @marketoLocaleTranslation @regression',
+    type: 'localeTranslation',
+    formType: 'essential',
+    locale: 'jp',
+    expectedSubmitText: '送信',
   },
 ];
 

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -349,6 +349,39 @@ test.describe('Marketo block test suite', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Privacy locale tests (MWPW-189425): regional privacy link hrefs must match
+  // the URL locale segment (e.g. /ie/ pages must use /ie/ links, not /uk/).
+  // Requires MARKETO_LIBS set to the PR branch — prod is not yet patched, so
+  // main/stage runs are skipped.
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.type === 'privacyLocale').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ baseURL }) => {
+        test.skip(
+          !cdnBranch || cdnBranch === 'main' || cdnBranch === 'stage',
+          'Privacy locale test requires MARKETO_LIBS env var set to a non-main/stage branch',
+        );
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+
+        await test.step('step-1: Navigate to the locale page', async () => {
+          await marketoBlock.navigateTo(testPage);
+        });
+
+        await test.step(`step-2: Verify privacy link hrefs contain /${feature.locale}/`, async () => {
+          const privacyLinks = marketoBlock.marketo.locator('a[href*="/privacy"]');
+          await privacyLinks.first().waitFor({ state: 'attached', timeout: 30000 });
+          const hrefs = await privacyLinks.evaluateAll((els) => els.map((el) => el.getAttribute('href')));
+          expect(hrefs.length, 'no privacy links rendered').toBeGreaterThan(0);
+          hrefs.forEach((href) => {
+            expect(href, `privacy link ${href} missing /${feature.locale}/`).toContain(`/${feature.locale}/`);
+          });
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Form-off tests: verify post-submission state is shown via ?form=off param
   // -------------------------------------------------------------------------
   features.filter((f) => f.type === 'formOff').forEach((feature) => {

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -368,14 +368,42 @@ test.describe('Marketo block test suite', () => {
           await marketoBlock.navigateTo(testPage);
         });
 
-        await test.step(`step-2: Verify privacy link hrefs contain /${feature.locale}/`, async () => {
-          const privacyLinks = marketoBlock.marketo.locator('a[href*="/privacy"]');
+        await test.step(`step-2: Select country ${feature.countryLabel} to trigger privacy link render`, async () => {
+          await marketoBlock.country.selectOption({ label: feature.countryLabel });
+        });
+
+        await test.step(`step-3: Verify privacy link hrefs contain /${feature.locale}/`, async () => {
+          const privacyLinks = marketoBlock.marketo.locator(`a[href*="/${feature.locale}/privacy"]`);
           await privacyLinks.first().waitFor({ state: 'attached', timeout: 30000 });
           const hrefs = await privacyLinks.evaluateAll((els) => els.map((el) => el.getAttribute('href')));
           expect(hrefs.length, 'no privacy links rendered').toBeGreaterThan(0);
           hrefs.forEach((href) => {
             expect(href, `privacy link ${href} missing /${feature.locale}/`).toContain(`/${feature.locale}/`);
           });
+        });
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Locale translation tests: verify form UI is translated for locale pages
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.type === 'localeTranslation').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ baseURL }) => {
+        test.skip(
+          !cdnBranch || cdnBranch === 'main' || cdnBranch === 'stage',
+          'Locale translation test requires MARKETO_LIBS env var set to a non-main/stage branch',
+        );
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+
+        await test.step('step-1: Navigate to the locale page', async () => {
+          await marketoBlock.navigateTo(testPage);
+        });
+
+        await test.step(`step-2: Verify submit button text is "${feature.expectedSubmitText}"`, async () => {
+          await expect(marketoBlock.submitButton).toHaveText(feature.expectedSubmitText, { timeout: 10000 });
         });
       });
     });

--- a/test/scripts/privacy.test.js
+++ b/test/scripts/privacy.test.js
@@ -1,0 +1,91 @@
+import { expect } from '@esm-bundle/chai';
+
+// The algorithm under test, defined here as a pure standalone function.
+// When the implementation is written in mkto/30_privacy/privacy_validation_process.js,
+// it will use this same logic internally (the helper functions there are private closures
+// and cannot be imported directly).
+function checkUrlPathLocale(pathname, regionalSiteMap) {
+  const pathSegment = pathname.split('/').filter(Boolean)[0];
+  if (!pathSegment) return null;
+  const knownRegionalSites = new Set(Object.values(regionalSiteMap));
+  return knownRegionalSites.has(pathSegment) ? pathSegment : null;
+}
+
+// Representative subset of the adobeRegionalSite map used in production
+const adobeRegionalSiteFixture = {
+  en_us: '', // United States — empty string (no regional path)
+  en_gb: 'uk', // United Kingdom
+  en_ie: 'ie', // Ireland
+  de_de: 'de', // Germany
+  fr_fr: 'fr', // France
+  en_au: 'au', // Australia
+  ja_jp: 'jp', // Japan
+};
+
+describe('checkUrlPathLocale — regression: existing locales', () => {
+  it('uk path still resolves to uk', () => {
+    expect(checkUrlPathLocale('/uk/products/test.html', adobeRegionalSiteFixture)).to.equal('uk');
+  });
+  it('de path still resolves to de', () => {
+    expect(checkUrlPathLocale('/de/solutions.html', adobeRegionalSiteFixture)).to.equal('de');
+  });
+  it('fr path still resolves to fr', () => {
+    expect(checkUrlPathLocale('/fr/contact.html', adobeRegionalSiteFixture)).to.equal('fr');
+  });
+  it('au path still resolves to au', () => {
+    expect(checkUrlPathLocale('/au/', adobeRegionalSiteFixture)).to.equal('au');
+  });
+  it('jp path still resolves to jp', () => {
+    expect(checkUrlPathLocale('/jp/acrobat/', adobeRegionalSiteFixture)).to.equal('jp');
+  });
+});
+
+describe('checkUrlPathLocale — fallback: unmapped locales', () => {
+  it('returns null for path segment that is a key (not value) in the map', () => {
+    // en_us is a key, not a value — its value is ''
+    expect(checkUrlPathLocale('/en_us/page.html', adobeRegionalSiteFixture)).to.equal(null);
+  });
+  it('returns null for completely unmapped segment', () => {
+    expect(checkUrlPathLocale('/xyz-unknown/page.html', adobeRegionalSiteFixture)).to.equal(null);
+  });
+  it('returns null when pathname is just a filename with no leading segments', () => {
+    expect(checkUrlPathLocale('contact.html', adobeRegionalSiteFixture)).to.equal(null);
+  });
+});
+
+describe('checkUrlPathLocale', () => {
+  it('returns ie for /ie/acrobat/contact.html', () => {
+    const result = checkUrlPathLocale('/ie/acrobat/contact.html', adobeRegionalSiteFixture);
+    expect(result).to.equal('ie');
+  });
+
+  it('returns uk for /uk/products/test.html', () => {
+    const result = checkUrlPathLocale('/uk/products/test.html', adobeRegionalSiteFixture);
+    expect(result).to.equal('uk');
+  });
+
+  it('returns de for /de/', () => {
+    const result = checkUrlPathLocale('/de/', adobeRegionalSiteFixture);
+    expect(result).to.equal('de');
+  });
+
+  it('returns null when first segment is not a regional site value', () => {
+    const result = checkUrlPathLocale('/acrobat/contact.html', adobeRegionalSiteFixture);
+    expect(result).to.equal(null);
+  });
+
+  it('returns null for an unknown prefix', () => {
+    const result = checkUrlPathLocale('/unknown-prefix/page.html', adobeRegionalSiteFixture);
+    expect(result).to.equal(null);
+  });
+
+  it('returns null for root path /', () => {
+    const result = checkUrlPathLocale('/', adobeRegionalSiteFixture);
+    expect(result).to.equal(null);
+  });
+
+  it('returns null for empty string pathname', () => {
+    const result = checkUrlPathLocale('', adobeRegionalSiteFixture);
+    expect(result).to.equal(null);
+  });
+});


### PR DESCRIPTION
Mirrored by adobecom/mkto-frms#22

## Changes

* **Privacy locale fix** — `check_url_path_locale()` consults the URL path first (e.g. `/ie/` → `ie`) before falling back to the HTML `lang` attribute. `/ie/` pages carry `lang="en-gb"` which previously mapped to `uk`, producing wrong consent link hrefs.
* **Unit tests** — `test/scripts/privacy.test.js` covers `check_url_path_locale()` across 15 cases.
* **Nala E2E** — tcid 19 (`@marketoPrivacyLocale`): navigates to `/ie/drafts/nala/blocks/marketo/full`, selects Ireland, asserts privacy link hrefs contain `/ie/`. tcid 20 (`@marketoLocaleTranslation`): navigates to `/jp/drafts/nala/blocks/marketo/essential`, asserts submit button text is `送信`. Both verified green across 6 browsers.
* `//# sourceURL=` pragma added to `privacy_validation_process.js`; `Updated` timestamp bumped (kept identical to the mkto-frms mirror).

## Test URLs

Test URLs:

Before: https://main--da-marketo--adobecom.aem.live/?martech=off
After: https://fix-privacy-links--da-marketo--adobecom.aem.live/?martech=off

**Privacy locale (IE):**
- Before: https://main--da-marketo--adobecom.aem.live/ie/drafts/nala/blocks/marketo/full?martech=off
- After: https://main--da-marketo--adobecom.aem.live/ie/drafts/nala/blocks/marketo/full?marketolibs=fix-privacy-links&martech=off

**Locale translation (JP):**
- Before: https://main--da-marketo--adobecom.aem.live/jp/drafts/nala/blocks/marketo/essential?martech=off
- After: https://main--da-marketo--adobecom.aem.live/jp/drafts/nala/blocks/marketo/essential?marketolibs=fix-privacy-links&martech=off

Resolves: [MWPW-189425](https://jira.corp.adobe.com/browse/MWPW-189425)