### PR TITLE
fix: skip JP prefecture sort in translateDDlbls

### DIFF
--- a/mkto/scripts/90_build/cleaning_validation.js
+++ b/mkto/scripts/90_build/cleaning_validation.js
@@ -1,9 +1,9 @@
 // ##
-// ## Updated 20251001T201149
+// ## Updated 20260615T104331
 // ##
 // ##
 // ##
-// ## 90_build/cleaning_validation.js - Cleaning and Validation 20251001T201149
+// ## 90_build/cleaning_validation.js - Cleaning and Validation 20260615T104331
 // ##
 
 var rendering_ready = false;
@@ -333,19 +333,25 @@ if (typeof window?.cleaning_validation != "function" && typeof form_dynamics !==
           dropdownField.add(select_lbloption);
         }
 
-        optionsArray = optionsArray.concat(unsortedOptions);
+        // Get the selected value from the Country field
+        let selectedCountry = document.querySelector('select[name="Country"] option:checked')?.value;
 
-        optionsArray.sort((a, b) => {
-          let aText = a.text.toLowerCase();
-          let bText = b.text.toLowerCase();
-          if (aText < bText) {
-            return -1;
-          }
-          if (aText > bText) {
-            return 1;
-          }
-          return 0;
-        });
+        // If the Country value is JP and the dropdownField is State, skip sorting the State list
+        if (selectedCountry !== "JP" && dropdownField !== "Select") {
+          optionsArray = optionsArray.concat(unsortedOptions);
+
+          optionsArray.sort((a, b) => {
+            let aText = a.text.toLowerCase();
+            let bText = b.text.toLowerCase();
+            if (aText < bText) {
+              return -1;
+            }
+            if (aText > bText) {
+              return 1;
+            }
+            return 0;
+          });
+        }
 
         if (select_lbloption) {
           optionsArray.unshift(select_lbloption);

--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -181,6 +181,14 @@ const features = [
     locale: 'jp',
     expectedSubmitText: '送信',
   },
+  {
+    tcid: '21',
+    name: '@marketo JP State dropdown preserves prefecture order (no alphabetical sort)',
+    path: ['/drafts/nala/blocks/marketo/full'],
+    tags: '@marketo @marketoJpPrefectures @regression',
+    type: 'jpPrefectures',
+    formType: 'full',
+  },
 ];
 
 export default features;

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -442,6 +442,89 @@ test.describe('Marketo block test suite', () => {
   });
 
   // -------------------------------------------------------------------------
+  // JP prefecture order tests: translateDDlbls must skip alphabetical sort
+  // when Country = JP so Marketo's natural prefecture order is preserved.
+  // Uses page.evaluate() to inject JP translation data directly, bypassing
+  // the locale-specific script load that only happens on ja_JP forms.
+  // Regression guard for github.com/adobecom/mkto-frms/issues/18.
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.type === 'jpPrefectures').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }) => {
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+        await marketoBlock.navigateTo(testPage);
+
+        // State is a conditional field not added to the DOM until a country with
+        // states/provinces is selected. Select US first to bring State into the
+        // DOM, then select JP via Playwright so the Country <select> truly
+        // reflects JP (option:checked = JP) when translateDDlbls re-runs.
+        // Programmatic JS assignment (select.value = 'JP') does not fire change
+        // events and has been observed to give stale option:checked results
+        // during MutationObserver callbacks.
+        await marketoBlock.country.selectOption({ value: 'US' });
+        await expect(marketoBlock.state).toBeVisible({ timeout: 10000 });
+        await marketoBlock.country.selectOption({ value: 'JP' });
+        await expect(marketoBlock.state).toBeVisible({ timeout: 10000 });
+
+        // Inject JP translation data and repopulate State with prefectures in the
+        // correct geographic order (Tokyo, Osaka, Aichi). Alphabetical sort by
+        // translated text (Unicode codepoint) would put Aichi (愛 U+611B) before
+        // Tokyo (東 U+6771), so Tokyo-first confirms the sort was skipped.
+        const result = await page.evaluate(() => new Promise((resolve) => {
+          const stateEl = document.querySelector('select[name="State"]');
+          const countryEl = document.querySelector('select[name="Country"]');
+          if (!stateEl || !countryEl) {
+            resolve({ error: 'Country or State select not found' });
+            return;
+          }
+
+          // Override translateState with a subset of real JP prefecture data.
+          window.translateState = {
+            東京都: '東京',
+            大阪府: '大阪',
+            愛知県: '愛知',
+          };
+
+          // Repopulate State with prefectures in correct geographic order.
+          // Country is already JP from the Playwright selectOption above; do not
+          // reassign countryEl.value here — it bypasses change events and leaves
+          // option:checked in stale state during the MutationObserver callback.
+          stateEl.innerHTML = '';
+          stateEl.appendChild(new Option('Select', '', true, true));
+          ['東京都', '大阪府', '愛知県'].forEach((val) => stateEl.appendChild(new Option(val, val)));
+
+          // Remove .translated so translateDDlbls will process State on next run.
+          stateEl.classList.remove('translated');
+
+          // Trigger the MutationObserver (cleaning_validation watches the form).
+          const mktoForm = document.querySelector('.mktoForm[id]');
+          if (mktoForm) {
+            const dummy = mktoForm.appendChild(document.createElement('span'));
+            setTimeout(() => mktoForm.removeChild(dummy), 50);
+          }
+
+          setTimeout(() => {
+            const opts = Array.from(stateEl.options)
+              .filter((o) => o.value !== '')
+              .map((o) => ({ value: o.value, text: o.text }));
+            resolve({ opts });
+          }, 400);
+        }));
+
+        expect(result.error, `Setup failed: ${result.error}`).toBeUndefined();
+        expect(result.opts.length, 'State should have 3 JP prefecture options').toBe(3);
+
+        // Tokyo (東京都 → 東京) must be first — the correct geographic order.
+        // If the sort ran, Aichi (愛 U+611B < 東 U+6771) would appear before Tokyo.
+        expect(result.opts[0].value, 'First option should be 東京都 (Tokyo)').toBe('東京都');
+        expect(result.opts[0].text, 'Tokyo option text should be translated to 東京').toBe('東京');
+        expect(result.opts[2].value, 'Third option should be 愛知県 (Aichi)').toBe('愛知県');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Program ID precedence tests: assert how mcz_marketoForm_pref.program.id
   // resolves (template default vs authored vs passthrough). Reads the data
   // layer directly and corroborates with the progressive sync request.


### PR DESCRIPTION
Mirrors: adobecom/mkto-frms#23
* In `translateDDlbls`, read the selected Country value and skip the alphabetical sort when Country = JP — preserves Marketo's geographic prefecture order
* Updated timestamp to `20260615T104331` (identical to adobecom/mkto-frms#23)
* Nala tcid 21 (`@marketoJpPrefectures`): injects JP translation data via `page.evaluate()`, asserts Tokyo (東京都) stays before Aichi (愛知県) after `translateDDlbls` runs (alphabetical sort would flip the order: 愛 U+611B < 東 U+6771)

Resolves [MWPW-199108](https://jira.corp.adobe.com/browse/MWPW-199108)
Workfront: [69d364fd0003411ab0af59fbe44ab062](https://experience.adobe.com/#/@wfadoberm/so:adoberm-Production/workfront/issue/69d364fd0003411ab0af59fbe44ab062/updates)

**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live
- After: https://fix-jp-prefectures--da-marketo--adobecom.aem.live

**Marketolibs URLs:**

- https://main--da-marketo--adobecom.aem.live/jp/drafts/nala/blocks/marketo/essential?marketolibs=fix-jp-prefectures
- https://main--da-bacom--adobecom.aem.live/jp/request-consultation?marketolibs=fix-jp-prefectures