### PR TITLE
Revert fix: skip JP prefecture sort in translateDDlbls

### DIFF
--- a/mkto/scripts/90_build/cleaning_validation.js
+++ b/mkto/scripts/90_build/cleaning_validation.js
@@ -333,11 +333,6 @@ if (typeof window?.cleaning_validation != "function" && typeof form_dynamics !==
           dropdownField.add(select_lbloption);
         }
 
-        // Get the selected value from the Country field
-        let selectedCountry = document.querySelector('select[name="Country"] option:checked')?.value;
-
-        // If the Country value is JP and the dropdownField is State, skip sorting the State list
-        if (selectedCountry !== "JP" && dropdownField !== "Select") {
           optionsArray = optionsArray.concat(unsortedOptions);
 
           optionsArray.sort((a, b) => {
@@ -351,7 +346,7 @@ if (typeof window?.cleaning_validation != "function" && typeof form_dynamics !==
             }
             return 0;
           });
-        }
+        
 
         if (select_lbloption) {
           optionsArray.unshift(select_lbloption);

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -467,7 +467,7 @@ test.describe('Marketo block test suite', () => {
   // -------------------------------------------------------------------------
   features.filter((f) => f.type === 'jpPrefectures').forEach((feature) => {
     feature.path.forEach((path) => {
-      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }) => {
+      test.skip(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }) => {
         const testPage = buildTestUrl(baseURL, path);
         console.info(`[Test Page]: ${testPage}`);
         await marketoBlock.navigateTo(testPage);


### PR DESCRIPTION
<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live/?martech=off
- After: https://revert-jp-prefectures--da-marketo--adobecom.aem.live/?martech=off
