### PR TITLE
[MWPW-201816] Adding nala tests for poi query param

### DIFF
--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -343,6 +343,17 @@ const features = [
     type: 'poiAutoHideOverridesAuthored',
     formType: 'full',
   },
+  {
+    tcid: '31',
+    name: '@marketo mktfrm_poi query param overrides the hard-coded POI and hides the field',
+    path: ['/drafts/nala/blocks/marketo/poi-param'],
+    tags: '@marketo @marketoFieldFilters @regression',
+    type: 'poiQueryParam',
+    formType: 'full',
+    basePoi: 'WORKFRONT',
+    poiParamValue: 'commerce',
+    expectedPoi: 'COMMERCE',
+  },
 ];
 
 export default features;

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -389,6 +389,46 @@ test.describe('Marketo block test suite', () => {
     });
   });
 
+  features.filter((f) => f.type === 'poiQueryParam').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+
+        await test.step('step-1: Verify baseline before mktfrm_poi is present', async () => {
+          await marketoBlock.navigateTo(testPage);
+
+          await expect(
+            marketoBlock.primaryProductInterest,
+            'POI select should still be visible before the mktfrm_poi param is added',
+          ).toBeVisible();
+
+          const poi = await page.evaluate(() => window.mcz_marketoForm_pref?.program?.poi);
+          expect(poi, 'Baseline hard-coded POI did not match the authored value').toBe(feature.basePoi);
+        });
+
+        await test.step('step-2: Add mktfrm_poi and verify it overrides the hard-coded POI', async () => {
+          const poiParam = testPage.includes('?') ? '&' : '?';
+          const testPageWithParam = `${testPage}${poiParam}mktfrm_poi=${feature.poiParamValue}`;
+          await marketoBlock.navigateTo(testPageWithParam);
+
+          await expect(
+            marketoBlock.primaryProductInterest,
+            'POI select should be hidden once the mktfrm_poi param is present',
+          ).not.toBeVisible();
+
+          const result = await page.evaluate(() => ({
+            poi: window.mcz_marketoForm_pref?.program?.poi,
+            productsFilter: window.mcz_marketoForm_pref?.field_filters?.products,
+          }));
+
+          expect(result.poi, 'POI did not change from the hard-coded value to the mktfrm_poi param value').toBe(feature.expectedPoi);
+          expect(result.productsFilter, 'Products filter was not forced to hidden').toBe('hidden');
+        });
+      });
+    });
+  });
+
   features.filter((f) => f.type === 'categoryFilters').forEach((feature) => {
     feature.path.forEach((path) => {
       test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {


### PR DESCRIPTION
Adding tests for the poi query param. 

Resolves: [MWPW-201816](https://jira.corp.adobe.com/browse/MWPW-201816)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live/?martech=off
- After: https://nala-poi-param--da-marketo--adobecom.aem.live/?martech=off
