### PR TITLE
MWPW-199375 Fix sticky lang for know visitor

### DIFF
--- a/mkto/scripts/30_privacy/privacy_validation_process.js
+++ b/mkto/scripts/30_privacy/privacy_validation_process.js
@@ -1,9 +1,9 @@
 // ##
-// ## Updated 20260612T141917
+// ## Updated 20260804T155027
 // ##
 // ##
 // ##
-// ## 30_privacy/privacy_validation_process.js - 20260612T141917
+// ## 30_privacy/privacy_validation_process.js - 20260804T155027
 // ##
 // ##
 
@@ -579,7 +579,7 @@ if (typeof window?.privacyValidation != "function") {
         }
       }
 
-      proposedBrowserLanguage = window?.mcz_marketoForm_pref?.profile?.prefLanguage ?? null;
+      proposedBrowserLanguage = check_content_lang();
       if (proposedBrowserLanguage != null && proposedBrowserLanguage != "") {
         proposedBrowserLanguage = confirm_lang_ok(proposedBrowserLanguage);
         if (has_langbeenSet == false) {
@@ -588,12 +588,13 @@ if (typeof window?.privacyValidation != "function") {
         }
         return proposedBrowserLanguage;
       } else {
-        proposedBrowserLanguage = check_content_lang();
+        proposedBrowserLanguage = window?.mcz_marketoForm_pref?.profile?.prefLanguage ?? null;
         if (proposedBrowserLanguage != null && proposedBrowserLanguage != "") {
           proposedBrowserLanguage = confirm_lang_ok(proposedBrowserLanguage);
-          dl_update_lang_pref(proposedBrowserLanguage);
-          field_update_mktoFormsLocale(proposedBrowserLanguage);
-          //mkf_c.log("proposedBrowserLanguage : ", proposedBrowserLanguage);
+          if (has_langbeenSet == false) {
+            dl_update_lang_pref(proposedBrowserLanguage);
+            field_update_mktoFormsLocale(proposedBrowserLanguage);
+          }
           return proposedBrowserLanguage;
         }
         proposedBrowserLanguage = check_browser_lang();
@@ -617,6 +618,8 @@ if (typeof window?.privacyValidation != "function") {
         return proposedBrowserLanguage;
       }
     }
+    window.fetch_lang_code = fetch_lang_code;
+
     function field_update_privacy_code(privacycode) {
       if (typeof privacycode == "undefined") {
         return;

--- a/test/mkto/scripts/privacy_validation_process.test.js
+++ b/test/mkto/scripts/privacy_validation_process.test.js
@@ -1,0 +1,65 @@
+import { expect } from '@esm-bundle/chai';
+
+function loadClassicScript(src) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+describe('privacy_validation_process.js: fetch_lang_code (MWPW-199375)', () => {
+  before(async () => {
+    await loadClassicScript('/mkto/scripts/00_config/marketo_form_setup_rules.js');
+    await loadClassicScript('/mkto/scripts/30_privacy/privacy_validation_rules.js');
+    await loadClassicScript('/mkto/scripts/30_privacy/privacy_validation_process.js');
+    // Running the module body exposes window.fetch_lang_code; the trailing
+    // wait_for_field_country() call is a no-op here since no .mktoForm exists.
+    window.privacyValidation();
+  });
+
+  const originalLang = document.documentElement.lang;
+
+  afterEach(() => {
+    document.documentElement.lang = originalLang;
+    window.mcz_marketoForm_pref = { profile: {} };
+  });
+
+  it('exposes fetch_lang_code on window', () => {
+    expect(window.fetch_lang_code).to.be.a('function');
+  });
+
+  it('prefers the current page locale over a known-visitor prefLanguage', async () => {
+    document.documentElement.lang = 'en';
+    window.mcz_marketoForm_pref = { profile: { prefLanguage: 'fr_fr' } };
+
+    const result = await window.fetch_lang_code();
+
+    expect(result).to.equal('en_us');
+    expect(window.mcz_marketoForm_pref.profile.prefLanguage).to.equal('en_us');
+  });
+
+  it('falls back to prefLanguage when the page has no locale signal', async () => {
+    document.documentElement.lang = '';
+    window.mcz_marketoForm_pref = { profile: { prefLanguage: 'fr_fr' } };
+
+    const result = await window.fetch_lang_code();
+
+    expect(result).to.equal('fr_fr');
+  });
+
+  it('still respects an explicit ?lang= URL param over the page locale', async () => {
+    document.documentElement.lang = 'en';
+    window.mcz_marketoForm_pref = { profile: { prefLanguage: 'fr_fr' } };
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', 'ja_jp');
+    window.history.replaceState({}, '', url);
+
+    const result = await window.fetch_lang_code();
+
+    window.history.replaceState({}, '', window.location.pathname);
+    expect(result).to.equal('ja_jp');
+  });
+});


### PR DESCRIPTION
* Update form lang priority order

Resolves: [MWPW-199375](https://jira.corp.adobe.com/browse/MWPW-199375)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live/?martech=off
- After: https://lang-code--da-marketo--adobecom.aem.live/?martech=off

**BACOM URLs:**

1. Filled out a form on the French site initially
  a. https://business.stage.adobe.com/fr/request-consultation.html
2. Navigate to the global english site 
  a. Before: https://business.stage.adobe.com/request-consultation.html
  b. After: https://business.stage.adobe.com/request-consultation.html?marketolibs=lang-code