### PR TITLE
MWPW-201774 Fix flex_event subtype

### DIFF
--- a/mkto/blocks/da-marketo/status.css
+++ b/mkto/blocks/da-marketo/status.css
@@ -51,7 +51,6 @@
 }
 
 .marketo-info-widget.miw-open .miw-icon::after {
-  top: 3px;
   transform: rotate(135deg);
   transition-duration: 0.2s;
 }
@@ -94,6 +93,11 @@
 .marketo-info-widget .miw-details span {
   font-weight: 300;
   word-break: break-all;
+}
+
+.marketo-info-widget .miw-details a {
+  color: #eee;
+  text-decoration: underline;
 }
 
 .marketo-info-widget .miw-close {

--- a/mkto/blocks/da-marketo/status.js
+++ b/mkto/blocks/da-marketo/status.js
@@ -3,39 +3,51 @@ import { LIBS } from '../../constants.js';
 const { createTag, loadStyle } = await import(`${LIBS}/utils/utils.js`);
 
 const BLOCK_BASE = new URL('../../', import.meta.url).href;
+const { hostname: BLOCK_HOSTNAME } = new URL(BLOCK_BASE);
+const MARKETO_LIBS = BLOCK_HOSTNAME === 'localhost' ? 'local' : BLOCK_HOSTNAME.split('--')[0];
 
-function createWidget(el, formID) {
-  const { template } = window.mcz_marketoForm_pref.form;
+function getDetails(el, formID) {
+  const { template, subtype } = window.mcz_marketoForm_pref.form;
   const successType = window.mcz_marketoForm_pref.form.success.type;
   const successContent = window.mcz_marketoForm_pref.form.success.content;
+  const successContentElement = successContent?.startsWith?.('http')
+    ? `<a href="${successContent}" target="_blank">${successContent}</a>`
+    : successContent;
   let multiStep = null;
+
   if (el.classList.contains('multi-step')) {
     multiStep = el.classList.contains('multi-3') ? '3-step' : '2-step';
   }
-  const { hostname } = new URL(BLOCK_BASE);
-  const marketoLibs = hostname === 'localhost' ? 'local' : hostname.split('--')[0];
-  const widget = createTag('div', { class: 'marketo-info-widget' });
-  widget.innerHTML = `
-    <span class="miw-badge"><span class="miw-icon"></span>Marketo</span>
-    <div class="miw-details hidden">
-      <button class="miw-close" aria-label="Close"></button>
-      <p>Form ID: <span>${formID || '(not set)'}</span></p>
-      <p>Template: <span>${template || '(not set)'}</span></p>
-      <p>Multi-step: <span>${multiStep || '(not set)'}</span></p>
-      <p>Success type: <span>${successType || '(not set)'}</span></p>
-      <p>Success content: <span>${successContent || '(not set)'}</span></p>
-      <p>Marketo libs: <span>${marketoLibs || '(not set)'}</span></p>
-    </div>
+
+  return `
+    <button class="miw-close" aria-label="Close"></button>
+    <p>Form ID: <span>${formID || '(not set)'}</span></p>
+    <p>Template: <span>${template || '(not set)'}</span></p>
+    <p>Subtype: <span>${subtype || '(not set)'}</span></p>
+    <p>Multi-step: <span>${multiStep || '(not set)'}</span></p>
+    <p>Success type: <span>${successType || '(not set)'}</span></p>
+    <p>Success content: <span>${successContentElement || '(not set)'}</span></p>
+    <p>Marketo libs: <span>${MARKETO_LIBS || '(not set)'}</span></p>
   `;
+}
 
-  widget.querySelector('.miw-badge').addEventListener('click', () => {
-    widget.querySelector('.miw-details').classList.toggle('hidden');
-    widget.classList.toggle('miw-open');
-  });
+function createWidget(el, formID) {
+  const icon = createTag('svg', { class: 'miw-icon' });
+  const badge = createTag('span', { class: 'miw-badge' }, [icon, 'Marketo']);
+  const details = createTag('div', { class: 'miw-details hidden' });
+  const widget = createTag('div', { class: 'marketo-info-widget' }, [badge, details]);
 
-  widget.querySelector('.miw-close').addEventListener('click', (e) => {
-    e.stopPropagation();
-    widget.remove();
+  widget.addEventListener('click', (e) => {
+    if (e.target.closest('.miw-close')) {
+      e.stopPropagation();
+      widget.remove();
+      return;
+    }
+    if (e.target.closest('.miw-badge')) {
+      if (details.classList.contains('hidden')) details.innerHTML = getDetails(el, formID);
+      details.classList.toggle('hidden');
+      widget.classList.toggle('miw-open');
+    }
   });
 
   return widget;
@@ -43,10 +55,6 @@ function createWidget(el, formID) {
 
 export default function main(el, formData) {
   loadStyle(`${BLOCK_BASE}blocks/da-marketo/status.css`, () => {
-    const formID = formData['form id'];
-    const refresh = () => el.querySelector('.marketo-info-widget')?.replaceWith(createWidget(el, formID));
-    new MutationObserver(refresh).observe(el, { attributes: true, attributeFilter: ['class'] });
-    window.addEventListener('mktoSubmit', refresh);
-    el.appendChild(createWidget(el, formID));
+    el.appendChild(createWidget(el, formData['form id']));
   });
 }

--- a/mkto/scripts/00_config/marketo_form_setup_rules.js
+++ b/mkto/scripts/00_config/marketo_form_setup_rules.js
@@ -1,9 +1,9 @@
 // ##
-// ## Updated 20251117T121800
+// ## Updated 20260804T165957
 // ##
 // ##
 // ##
-// ##  00_config/marketo_form_setup_rules.js - 20251117T121800
+// ##  00_config/marketo_form_setup_rules.js - 20260804T165957
 // ##
 // ##
 
@@ -285,12 +285,12 @@ if (typeof window.mcz_marketoForm_pref_example == "undefined") {
         email: "join", // Subscriptions
       },
       templateVersions: {
-        dme_flex_contact: "dme_flex_contact",
-        dme_flex_content: "dme_flex_content",
-        dme_flex_event: "dme_flex_event",
-        comb_flex_contact: "comb_flex_contact",
-        comb_flex_content: "comb_flex_content",
-        comb_flex_event: "comb_flex_event",
+        dme_flex_contact: "flex_contact",
+        dme_flex_content: "flex_content",
+        dme_flex_event: "flex_event",
+        comb_flex_contact: "flex_contact",
+        comb_flex_content: "flex_content",
+        comb_flex_event: "flex_event",
       },
       subtypeTemplate: {
         //subtypes assigned to templates

--- a/mkto/scripts/90_build/global.js
+++ b/mkto/scripts/90_build/global.js
@@ -1,8 +1,8 @@
 // ##
-// ## Updated 20260720T183306
+// ## Updated 20260806T154953
 // ##
 // ##
-// ##  90_build/global.js - 20260720T183306
+// ##  90_build/global.js - 20260806T154953
 // ##
 
 if (typeof window?.mkto_checkAdobePrivacy == "undefined") {
@@ -1257,6 +1257,8 @@ if (typeof window?.mkto_checkAdobePrivacy == "undefined") {
 
     aTLg("---");
     mkf_c.log(templateLog);
+    mczPrefs.flags = mczPrefs.flags || {};
+    mczPrefs.flags.mkto_checkTemplate = true;
     mkf_c.groupEnd(groupLBL);
   };
 

--- a/nala/features/marketo.block.spec.js
+++ b/nala/features/marketo.block.spec.js
@@ -354,6 +354,17 @@ const features = [
     poiParamValue: 'commerce',
     expectedPoi: 'COMMERCE',
   },
+  {
+    tcid: '32',
+    name: '@marketo MWPW-201774: comb_flex_event normalizes to flex_event and resolves strategy_webinar subtype',
+    path: ['/drafts/nala/blocks/marketo/template-versions'],
+    tags: '@marketo @marketoTemplateVersions @regression',
+    type: 'templateVersion',
+    formType: 'full',
+    expectedTemplate: 'flex_event',
+    expectedSubtype: 'strategy_webinar',
+    sites: ['da-marketo'],
+  },
 ];
 
 export default features;

--- a/nala/selectors/marketo.block.page.js
+++ b/nala/selectors/marketo.block.page.js
@@ -148,6 +148,17 @@ export default class MarketoBlock {
   }
 
   /**
+   * Returns the Marketo form subtype (channel) resolved from the template.
+   * @returns {Promise<string>} e.g. 'strategy_webinar', 'unknown'
+   */
+  async getFormSubtype() {
+    const subtype = await this.page.evaluate(
+      () => window.mcz_marketoForm_pref?.form?.subtype,
+    );
+    return subtype || 'unknown';
+  }
+
+  /**
    * Waits until program.id is FINAL. An authored program.id is set at block
    * init, then template processing may override it — so "non-empty" is not
    * enough. form.status flips to 'ready' only after the last MCZ script runs

--- a/nala/selectors/marketo.block.page.js
+++ b/nala/selectors/marketo.block.page.js
@@ -168,7 +168,7 @@ export default class MarketoBlock {
    */
   async waitForProgramIdResolved() {
     await this.page.waitForFunction(
-      () => window.mcz_marketoForm_pref?.form?.status === 'ready',
+      () => window.mcz_marketoForm_pref?.flags?.mkto_checkTemplate === true,
       undefined,
       { timeout: 20000 },
     );

--- a/nala/tests/marketo.block.test.js
+++ b/nala/tests/marketo.block.test.js
@@ -682,4 +682,36 @@ test.describe('Marketo block test suite', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Template version normalization tests (MWPW-201774): templateVersions must
+  // map dme_/comb_ prefixed template variants (e.g. comb_flex_event) down to
+  // their bare template key (flex_event) BEFORE subtypeTemplate resolves the
+  // channel/subtype. Regression guard for the June 2026 templateVersions
+  // regression that left flex_event variants unnormalized, mis-assigning
+  // strategy_webinar forms as request_for_information.
+  // -------------------------------------------------------------------------
+  features.filter((f) => f.type === 'templateVersion').forEach((feature) => {
+    feature.path.forEach((path) => {
+      test(`${feature.tcid}: ${feature.name}, ${feature.tags}, path: ${path}`, async ({ page, baseURL }, testInfo) => {
+        test.skip(!isFeatureAllowedOnSite(feature), `not applicable to site "${currentSite}"`);
+        const testPage = buildTestUrl(baseURL, path);
+        console.info(`[Test Page]: ${testPage}`);
+
+        await test.step('step-1: Navigate and wait for template processing to resolve', async () => {
+          // waitForField:false — flex_event hides several standard fields;
+          // this test only inspects the resolved data layer state.
+          await marketoBlock.navigateTo(testPage, { waitForField: false });
+        });
+
+        await test.step(`step-2: form.template normalizes to "${feature.expectedTemplate}"`, async () => {
+          expect(await marketoBlock.getFormTemplate()).toBe(feature.expectedTemplate);
+        });
+
+        await test.step(`step-3: form.subtype resolves to "${feature.expectedSubtype}"`, async () => {
+          expect(await marketoBlock.getFormSubtype()).toBe(feature.expectedSubtype);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
* Fix flex_event subtype so template keys are normalized 

Resolves: [MWPW-201774](https://jira.corp.adobe.com/browse/MWPW-201774)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-marketo--adobecom.aem.live/drafts/nala/blocks/marketo/template-versions?martech=off
- After: https://main--da-marketo--adobecom.aem.live/drafts/nala/blocks/marketo/template-versions?martech=off&marketolibs=flex-event

https://flex-event--da-marketo--adobecom.aem.live/?martech=off